### PR TITLE
Added material inquirer on component creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,55 @@
+---
+language: node_js
+node_js:
+  - "10"
+
+sudo: false
+dist: xenial
+
+cache:
+  yarn: true
+
+env:
+  global:
+    # See https://git.io/vdao3 for details.
+    - JOBS=1
+    - APP=./packages/react-app
+    - CLI=./packages/react-cli
+    - ADDON_GENERATORS=./packages/react-generators
+
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+
+
+lint: &lint
+  script:
+    - ls -la
+    - ls -la packages/
+    - ls -la $PROJECT
+    - scripts/install.sh
+    - scripts/lint.sh
+
+
+jobs:
+  fail_fast: true
+
+  include:
+    - stage: "Quality"
+      <<: *lint
+      name: "Lint JS/TS (app)"
+      env:
+      - PROJECT=$APP
+
+    - name: "Lint JS/TS (cli)"
+      <<: *lint
+      env:
+      - PROJECT=$CLI
+
+    - name: "Lint JS/TS (generators)"
+      <<: *lint
+      env:
+      - PROJECT=$ADDON_GENERATORS
+
+    - stage: "App Generation Smoke Test"
+      script: echo "Need non-interactive mode"

--- a/packages/react-app/files/package.json
+++ b/packages/react-app/files/package.json
@@ -182,6 +182,8 @@
     "serve-static": "^1.13.2",
 
     "sass-loader": "^7.0.3",
+    "static-route-paths": "^0.2.2",
+
     "node-sass": "^4.9.0",
     "source-map-loader": "^0.2.4",
     "style-loader": "^0.23.0",

--- a/packages/react-app/files/src/ui/routes/paths.ts
+++ b/packages/react-app/files/src/ui/routes/paths.ts
@@ -1,38 +1,12 @@
-export function pathTemplate(pathObject) {
-  return pathObject.name || pathObject.path;
-}
+import { route } from 'static-route-paths';
 
-export function resolvedPath(pathObject, ...args) {
-  if (typeof pathObject.path === 'function') {
-    return pathObject.path(...args);
-  }
+export const paths = route({
+  root: route(),
+  todos: route('todos', {
+    show: route(':id'),
+  }),
 
-  return pathObject.path;
-}
-
-export const paths = {
-  root: { path: '/' }  ,
-  todos: {
-    path: '/todos',
-    forStatus: {
-      path(status){
-        return `/todos/${status}`;
-      },
-      name: '/todos/:status'
-    },
-  },
-  posts: {
-    path: '/posts/',
-    forPost: {
-      path(postId) {
-        return `/posts/${postId}`;
-      },
-      name: '/posts/:id'
-    },
-  },
-  errors: {
-    notFound: {
-      path: '/not-found'
-    }
-  }
-}
+  errors: route({
+    notFound: route('not-found'),
+  }),
+});

--- a/packages/react-app/index.js
+++ b/packages/react-app/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const path = require('path');
-const rimraf = require('rimraf');
-const fs = require('fs');
 const stringUtil = require('ember-cli-string-utils');
 
 module.exports = {

--- a/packages/react-cli/.eslintignore
+++ b/packages/react-cli/.eslintignore
@@ -3,3 +3,4 @@
 /src/public
 /src/locales
 /dist
+/lib

--- a/packages/react-cli/.eslintrc.js
+++ b/packages/react-cli/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
   env: {
     browser: false,
     node: true,
+    es6: true,
   },
   plugins: [
     'prettier',
@@ -24,6 +25,8 @@ module.exports = {
     '@typescript-eslint/explicit-member-accessibility': 'off',
     // returning undefined / void is fine.
     '@typescript-eslint/explicit-function-return-type': 'off',
+    // this rule does not make sense when usages are runtime.
+    '@typescript-eslint/no-use-before-define': 'off',
 
     /**
      * general

--- a/packages/react-cli/README.md
+++ b/packages/react-cli/README.md
@@ -60,6 +60,23 @@ EXAMPLES
 
 _See code: [src/commands/generate.ts](https://github.com/developertown/react-cli/blob/v0.10.1/src/commands/generate.ts)_
 
+## `react material COMPONENT-NAME
+
+Creates components with Material Components installed
+
+```
+USAGE
+  $ react generateMaterial NAME
+
+ALIASES
+  $ react material
+  $ react m
+
+EXAMPLES
+  $ react material component-name
+  $ react m path/to/component
+```
+_See Code: [src/commands/generateMaterial.ts](https://github.com/developertown/react-cli/blob/v0.10.1/src/commands/generateMaterial.ts)_
 ## `react help [COMMAND]`
 
 display help for react

--- a/packages/react-cli/src/commands/fetch-configs.ts
+++ b/packages/react-cli/src/commands/fetch-configs.ts
@@ -1,0 +1,33 @@
+import { Command } from '@oclif/command';
+import { ensureDependencies } from '../tasks/ensure-dependiencies';
+import Listr from 'listr';
+import { downloadTSConfigFiles } from '../tasks/download-ts-config';
+import { exec } from '../utils/shell';
+import { ensureWeAreInAProjectDirectory } from '../tasks/ensure-we-are-in-a-project-directory';
+
+export class FetchConfigsCommand extends Command {
+  static description = 'Fetches config files for linting and typescript projects';
+
+  static examples = ['$ react fetch-configs'];
+
+  async run() {
+    await ensureDependencies();
+
+    const tasks = new Listr([
+      {
+        title: 'Checking to make sure we are in a project directory',
+        task: () => ensureWeAreInAProjectDirectory(),
+      },
+      {
+        title: 'Downloading shared config for DeveloperTown',
+        task: () => downloadTSConfigFiles(),
+      },
+      {
+        title: 'Installing Dependencies',
+        task: () => exec(`yarn install`),
+      },
+    ]);
+
+    await tasks.run();
+  }
+}

--- a/packages/react-cli/src/commands/generate.ts
+++ b/packages/react-cli/src/commands/generate.ts
@@ -3,7 +3,7 @@ import { ensureDependencies } from '../tasks/ensure-dependiencies';
 import { runEmber, runEmberInteractively } from '../tasks/run-ember';
 import { exec } from '../utils/shell';
 import Listr from 'listr';
-import inquirer = require('inquirer');
+import inquirer from 'inquirer';
 
 export class GenerateCommand extends Command {
   static description =
@@ -18,6 +18,8 @@ export class GenerateCommand extends Command {
     '',
     '$ react g route route-name',
     '$ react g route path/to/route-name',
+    '',
+    '$ react g material component-name'
   ];
 
   static args = [{ name: 'generator', required: true }, { name: 'name', required: true }];
@@ -29,15 +31,13 @@ export class GenerateCommand extends Command {
       hidden: false,
       multiple: false,
       required: false,
-    }),
-    button: flags.string({
-      name: 'Button'
     })
   };
 
   async run() {
     const { args, flags } = this.parse(GenerateCommand);
-
+    let options = [];
+    
     await ensureDependencies();
 
     let generatorArgs = ['g', args.generator, args.name];
@@ -46,23 +46,25 @@ export class GenerateCommand extends Command {
       generatorArgs.push(`--path=routes/${flags.route}/-components`);
     }
 
-    const answers: any = await inquirer.prompt([
-      {
-        type: 'checkbox',
-        message: 'Select Material Components',
-        name: 'materialComponent',
-        choices: [
-          { name: 'Button', value: 'Button' },
-          { name: 'TextField', value: 'TextField' },
-          { name: 'Table', value: 'Table' },
-          { name: 'Card', value: 'Card' }
-        ]
-      }
-    ])
+    if(args.generator === 'material'){
+      const answers: any = await inquirer.prompt([
+        {
+          type: 'checkbox',
+          message: 'Select Material Components',
+          name: 'materialComponent',
+          choices: [
+            { name: 'Button', value: 'Button' },
+            { name: 'TextField', value: 'TextField' },
+            { name: 'Table', value: 'Table' },
+            { name: 'Card', value: 'Card' }
+          ]
+        }
+      ])
+      options = [
+        ...answers.materialComponent.map((component: string) => `--${component}`)
+      ]
+    }
 
-    let options = [
-      ...answers.materialComponent.map((component: string) => `--${component}`)
-    ]
     await runEmberInteractively([...generatorArgs, ...options].join(' '));
   }
 }

--- a/packages/react-cli/src/commands/generate.ts
+++ b/packages/react-cli/src/commands/generate.ts
@@ -15,7 +15,7 @@ export class GenerateCommand extends Command {
     '$ react g component component-name --route=dashboard/posts',
     '',
     '$ react g route route-name',
-    '$ react g route path/to/route-name'
+    '$ react g route path/to/route-name',
   ];
 
   static args = [{ name: 'generator', required: true }, { name: 'name', required: true }];
@@ -27,12 +27,12 @@ export class GenerateCommand extends Command {
       hidden: false,
       multiple: false,
       required: false,
-    })
+    }),
   };
 
   async run() {
     const { args, flags } = this.parse(GenerateCommand);
-    
+
     await ensureDependencies();
 
     let generatorArgs = ['g', args.generator, args.name];

--- a/packages/react-cli/src/commands/generate.ts
+++ b/packages/react-cli/src/commands/generate.ts
@@ -15,7 +15,6 @@ export class GenerateCommand extends Command {
     '$ react g component component-name',
     '$ react g component path/to/component-name',
     '$ react g component component-name --route=dashboard/posts',
-    '$ react g component component-name --Button',
     '',
     '$ react g route route-name',
     '$ react g route path/to/route-name',

--- a/packages/react-cli/src/commands/generate.ts
+++ b/packages/react-cli/src/commands/generate.ts
@@ -3,7 +3,7 @@ import { ensureDependencies } from '../tasks/ensure-dependiencies';
 import { runEmber, runEmberInteractively } from '../tasks/run-ember';
 import { exec } from '../utils/shell';
 import Listr from 'listr';
-import inquirer = require('inquirer');
+import inquirer from 'inquirer';
 
 export class GenerateCommand extends Command {
   static description =
@@ -18,6 +18,8 @@ export class GenerateCommand extends Command {
     '',
     '$ react g route route-name',
     '$ react g route path/to/route-name',
+    '',
+    '$ react g material component-name'
   ];
 
   static args = [{ name: 'generator', required: true }, { name: 'name', required: true }];
@@ -29,15 +31,13 @@ export class GenerateCommand extends Command {
       hidden: false,
       multiple: false,
       required: false,
-    }),
-    button: flags.string({
-      name: 'Button'
     })
   };
 
   async run() {
     const { args, flags } = this.parse(GenerateCommand);
-
+    let options = [];
+    
     await ensureDependencies();
 
     let generatorArgs = ['g', args.generator, args.name];
@@ -46,23 +46,25 @@ export class GenerateCommand extends Command {
       generatorArgs.push(`--path=${flags.route}/-components`);
     }
 
-    const answers: any = await inquirer.prompt([
-      {
-        type: 'checkbox',
-        message: 'Select Material Components',
-        name: 'materialComponent',
-        choices: [
-          { name: 'Button', value: 'Button' },
-          { name: 'TextField', value: 'TextField' },
-          { name: 'Table', value: 'Table' },
-          { name: 'Card', value: 'Card' }
-        ]
-      }
-    ])
+    if(args.generator === 'material'){
+      const answers: any = await inquirer.prompt([
+        {
+          type: 'checkbox',
+          message: 'Select Material Components',
+          name: 'materialComponent',
+          choices: [
+            { name: 'Button', value: 'Button' },
+            { name: 'TextField', value: 'TextField' },
+            { name: 'Table', value: 'Table' },
+            { name: 'Card', value: 'Card' }
+          ]
+        }
+      ])
+      options = [
+        ...answers.materialComponent.map((component: string) => `--${component}`)
+      ]
+    }
 
-    let options = [
-      ...answers.materialComponent.map((component: string) => `--${component}`)
-    ]
     await runEmberInteractively([...generatorArgs, ...options].join(' '));
   }
 }

--- a/packages/react-cli/src/commands/generate.ts
+++ b/packages/react-cli/src/commands/generate.ts
@@ -3,6 +3,7 @@ import { ensureDependencies } from '../tasks/ensure-dependiencies';
 import { runEmber, runEmberInteractively } from '../tasks/run-ember';
 import { exec } from '../utils/shell';
 import Listr from 'listr';
+import inquirer = require('inquirer');
 
 export class GenerateCommand extends Command {
   static description =
@@ -14,6 +15,7 @@ export class GenerateCommand extends Command {
     '$ react g component component-name',
     '$ react g component path/to/component-name',
     '$ react g component component-name --route=dashboard/posts',
+    '$ react g component component-name --Button',
     '',
     '$ react g route route-name',
     '$ react g route path/to/route-name',
@@ -29,6 +31,9 @@ export class GenerateCommand extends Command {
       multiple: false,
       required: false,
     }),
+    button: flags.string({
+      name: 'Button'
+    })
   };
 
   async run() {
@@ -42,6 +47,23 @@ export class GenerateCommand extends Command {
       generatorArgs.push(`--path=${flags.route}/-components`);
     }
 
-    await runEmberInteractively(generatorArgs.join(' '));
+    const answers: any = await inquirer.prompt([
+      {
+        type: 'checkbox',
+        message: 'Select Material Components',
+        name: 'materialComponent',
+        choices: [
+          { name: 'Button', value: 'Button' },
+          { name: 'TextField', value: 'TextField' },
+          { name: 'Table', value: 'Table' },
+          { name: 'Card', value: 'Card' }
+        ]
+      }
+    ])
+
+    let options = [
+      ...answers.materialComponent.map((component: string) => `--${component}`)
+    ]
+    await runEmberInteractively([...generatorArgs, ...options].join(' '));
   }
 }

--- a/packages/react-cli/src/commands/generate.ts
+++ b/packages/react-cli/src/commands/generate.ts
@@ -2,8 +2,6 @@ import { Command, flags } from '@oclif/command';
 import { ensureDependencies } from '../tasks/ensure-dependiencies';
 import { runEmber, runEmberInteractively } from '../tasks/run-ember';
 import { exec } from '../utils/shell';
-import Listr from 'listr';
-import inquirer from 'inquirer';
 
 export class GenerateCommand extends Command {
   static description =
@@ -17,9 +15,7 @@ export class GenerateCommand extends Command {
     '$ react g component component-name --route=dashboard/posts',
     '',
     '$ react g route route-name',
-    '$ react g route path/to/route-name',
-    '',
-    '$ react g material component-name'
+    '$ react g route path/to/route-name'
   ];
 
   static args = [{ name: 'generator', required: true }, { name: 'name', required: true }];
@@ -36,7 +32,6 @@ export class GenerateCommand extends Command {
 
   async run() {
     const { args, flags } = this.parse(GenerateCommand);
-    let options = [];
     
     await ensureDependencies();
 
@@ -46,25 +41,6 @@ export class GenerateCommand extends Command {
       generatorArgs.push(`--path=${flags.route}/-components`);
     }
 
-    if(args.generator === 'material'){
-      const answers: any = await inquirer.prompt([
-        {
-          type: 'checkbox',
-          message: 'Select Material Components',
-          name: 'materialComponent',
-          choices: [
-            { name: 'Button', value: 'Button' },
-            { name: 'TextField', value: 'TextField' },
-            { name: 'Table', value: 'Table' },
-            { name: 'Card', value: 'Card' }
-          ]
-        }
-      ])
-      options = [
-        ...answers.materialComponent.map((component: string) => `--${component}`)
-      ]
-    }
-
-    await runEmberInteractively([...generatorArgs, ...options].join(' '));
+    await runEmberInteractively([...generatorArgs].join(' '));
   }
 }

--- a/packages/react-cli/src/commands/generate.ts
+++ b/packages/react-cli/src/commands/generate.ts
@@ -2,8 +2,6 @@ import { Command, flags } from '@oclif/command';
 import { ensureDependencies } from '../tasks/ensure-dependiencies';
 import { runEmber, runEmberInteractively } from '../tasks/run-ember';
 import { exec } from '../utils/shell';
-import Listr from 'listr';
-import inquirer from 'inquirer';
 
 export class GenerateCommand extends Command {
   static description =
@@ -17,9 +15,7 @@ export class GenerateCommand extends Command {
     '$ react g component component-name --route=dashboard/posts',
     '',
     '$ react g route route-name',
-    '$ react g route path/to/route-name',
-    '',
-    '$ react g material component-name'
+    '$ react g route path/to/route-name'
   ];
 
   static args = [{ name: 'generator', required: true }, { name: 'name', required: true }];
@@ -36,7 +32,6 @@ export class GenerateCommand extends Command {
 
   async run() {
     const { args, flags } = this.parse(GenerateCommand);
-    let options = [];
     
     await ensureDependencies();
 
@@ -46,25 +41,6 @@ export class GenerateCommand extends Command {
       generatorArgs.push(`--path=routes/${flags.route}/-components`);
     }
 
-    if(args.generator === 'material'){
-      const answers: any = await inquirer.prompt([
-        {
-          type: 'checkbox',
-          message: 'Select Material Components',
-          name: 'materialComponent',
-          choices: [
-            { name: 'Button', value: 'Button' },
-            { name: 'TextField', value: 'TextField' },
-            { name: 'Table', value: 'Table' },
-            { name: 'Card', value: 'Card' }
-          ]
-        }
-      ])
-      options = [
-        ...answers.materialComponent.map((component: string) => `--${component}`)
-      ]
-    }
-
-    await runEmberInteractively([...generatorArgs, ...options].join(' '));
+    await runEmberInteractively([...generatorArgs].join(' '));
   }
 }

--- a/packages/react-cli/src/commands/generate.ts
+++ b/packages/react-cli/src/commands/generate.ts
@@ -3,6 +3,7 @@ import { ensureDependencies } from '../tasks/ensure-dependiencies';
 import { runEmber, runEmberInteractively } from '../tasks/run-ember';
 import { exec } from '../utils/shell';
 import Listr from 'listr';
+import inquirer = require('inquirer');
 
 export class GenerateCommand extends Command {
   static description =
@@ -14,6 +15,7 @@ export class GenerateCommand extends Command {
     '$ react g component component-name',
     '$ react g component path/to/component-name',
     '$ react g component component-name --route=dashboard/posts',
+    '$ react g component component-name --Button',
     '',
     '$ react g route route-name',
     '$ react g route path/to/route-name',
@@ -29,6 +31,9 @@ export class GenerateCommand extends Command {
       multiple: false,
       required: false,
     }),
+    button: flags.string({
+      name: 'Button'
+    })
   };
 
   async run() {
@@ -42,6 +47,23 @@ export class GenerateCommand extends Command {
       generatorArgs.push(`--path=routes/${flags.route}/-components`);
     }
 
-    await runEmberInteractively(generatorArgs.join(' '));
+    const answers: any = await inquirer.prompt([
+      {
+        type: 'checkbox',
+        message: 'Select Material Components',
+        name: 'materialComponent',
+        choices: [
+          { name: 'Button', value: 'Button' },
+          { name: 'TextField', value: 'TextField' },
+          { name: 'Table', value: 'Table' },
+          { name: 'Card', value: 'Card' }
+        ]
+      }
+    ])
+
+    let options = [
+      ...answers.materialComponent.map((component: string) => `--${component}`)
+    ]
+    await runEmberInteractively([...generatorArgs, ...options].join(' '));
   }
 }

--- a/packages/react-cli/src/commands/generateMaterial.ts
+++ b/packages/react-cli/src/commands/generateMaterial.ts
@@ -4,44 +4,37 @@ import { runEmberInteractively } from '../tasks/run-ember';
 import inquirer = require('inquirer');
 
 export class GenerateMaterialCommand extends Command {
-    static description = 'Creates components with Material Components installed';
+  static description = 'Creates components with Material Components installed';
 
-    static aliases = ['material', 'm'];
-    
-    static examples = [
-        '$ react material component-name',
-        '$ react m path/to/component'
-    ]
+  static aliases = ['material', 'm'];
 
-    static args = [{ name: 'name', required: true }];
+  static examples = ['$ react material component-name', '$ react m path/to/component'];
 
-    async run(): Promise<any> {
-        const { args } = this.parse(GenerateMaterialCommand);
-        let options = [];
+  static args = [{ name: 'name', required: true }];
 
-        await ensureMaterialExists();
+  async run(): Promise<any> {
+    const { args } = this.parse(GenerateMaterialCommand);
+    let options = [];
 
-        const answers: any = await inquirer.prompt([
-            {
-                type: 'checkbox',
-                message: 'Select Material Components',
-                name: 'materialComponent',
-                choices: [
-                    { name: 'Button', value: 'Button' },
-                    { name: 'TextField', value: 'TextField' },
-                    { name: 'Table', value: 'Table' },
-                    { name: 'Card', value: 'Card' }
-                ]
-            }
-        ])
-        options = [
-            ...answers.materialComponent.map((component: string) => `--${component}`)
-        ]
+    await ensureMaterialExists();
 
-        let generatorArgs = ['g', 'material', args.name];
+    const answers: any = await inquirer.prompt([
+      {
+        type: 'checkbox',
+        message: 'Select Material Components',
+        name: 'materialComponent',
+        choices: [
+          { name: 'Button', value: 'Button' },
+          { name: 'TextField', value: 'TextField' },
+          { name: 'Table', value: 'Table' },
+          { name: 'Card', value: 'Card' },
+        ],
+      },
+    ]);
+    options = [...answers.materialComponent.map((component: string) => `--${component}`)];
 
-        await runEmberInteractively([...generatorArgs, , ...options].join(' '));
-    }
+    let generatorArgs = ['g', 'material', args.name];
 
+    await runEmberInteractively([...generatorArgs, ...options].join(' '));
+  }
 }
-// TODO: handle class and functional components

--- a/packages/react-cli/src/commands/generateMaterial.ts
+++ b/packages/react-cli/src/commands/generateMaterial.ts
@@ -6,7 +6,7 @@ import inquirer = require('inquirer');
 export class GenerateMaterialCommand extends Command {
     static description = 'Creates components with Material Components installed';
 
-    static aliases = ['m'];
+    static aliases = ['material', 'm'];
     
     static examples = [
         '$ react material component-name',

--- a/packages/react-cli/src/commands/material.ts
+++ b/packages/react-cli/src/commands/material.ts
@@ -1,0 +1,47 @@
+import Command from '@oclif/command';
+import { ensureMaterialExists } from '../tasks/ensure-material-exist';
+import { runEmberInteractively } from '../tasks/run-ember';
+import inquirer = require('inquirer');
+
+export class GenerateMaterialCommand extends Command {
+    static description = 'Creates components with Material Components installed';
+
+    static aliases = ['m'];
+    
+    static examples = [
+        '$ react material component-name',
+        '$ react m path/to/component'
+    ]
+
+    static args = [{ name: 'name', required: true }];
+
+    async run(): Promise<any> {
+        const { args } = this.parse(GenerateMaterialCommand);
+        let options = [];
+
+        await ensureMaterialExists();
+
+        const answers: any = await inquirer.prompt([
+            {
+                type: 'checkbox',
+                message: 'Select Material Components',
+                name: 'materialComponent',
+                choices: [
+                    { name: 'Button', value: 'Button' },
+                    { name: 'TextField', value: 'TextField' },
+                    { name: 'Table', value: 'Table' },
+                    { name: 'Card', value: 'Card' }
+                ]
+            }
+        ])
+        options = [
+            ...answers.materialComponent.map((component: string) => `--${component}`)
+        ]
+
+        let generatorArgs = ['g', 'material', args.name];
+
+        await runEmberInteractively([...generatorArgs, , ...options].join(' '));
+    }
+
+}
+// TODO: handle class and functional components

--- a/packages/react-cli/src/commands/new.ts
+++ b/packages/react-cli/src/commands/new.ts
@@ -7,10 +7,7 @@ import { downloadTSConfigFiles } from '../tasks/download-ts-config';
 import { exec } from '../utils/shell';
 import { appBlueprint } from '../utils/info';
 
-const requiredOptions = [
-  `--blueprint ${appBlueprint}`,
-  '--skip-npm',
-];
+const requiredOptions = [`--blueprint ${appBlueprint}`, '--skip-npm'];
 
 export class NewCommand extends Command {
   static description = 'Creates a new react application';
@@ -57,7 +54,7 @@ export class NewCommand extends Command {
         message: 'Select UI Framework',
         name: 'style',
         choices: [
-          { name: 'Material UI', value: 'materialUi' }
+          { name: 'Material UI', value: 'materialUi' },
           // TODO:
           // - just sass?
           //   - sass is default right now, do we want sass to be an option instead?
@@ -71,7 +68,7 @@ export class NewCommand extends Command {
     let options = [
       args.projectName || answers.name,
       ...answers.functionality.map((feat: string) => `--${feat}`),
-      ...answers.style.map((styleFramework: string) => `--${styleFramework}`)
+      ...answers.style.map((styleFramework: string) => `--${styleFramework}`),
     ];
 
     let argsForEmber = ['new', ...options, ...requiredOptions].join(' ');
@@ -91,8 +88,8 @@ export class NewCommand extends Command {
       },
       {
         title: 'Formatting code',
-        task: () => exec(`cd ${options[0]} && yarn lint:js --fix --quiet`)
-      }
+        task: () => exec(`cd ${options[0]} && yarn lint:js --fix --quiet`),
+      },
     ]);
 
     await tasks.run();

--- a/packages/react-cli/src/commands/prepare.ts
+++ b/packages/react-cli/src/commands/prepare.ts
@@ -25,7 +25,8 @@ export class PrepareCommand extends Command {
             },
             {
               title: 'Installing blueprint dependencies',
-              task: () => exec('yarn add --dev ember-cli @developertown/react-generators-blueprint'),
+              task: () =>
+                exec('yarn add --dev ember-cli @developertown/react-generators-blueprint'),
             },
           ]),
       },

--- a/packages/react-cli/src/commands/upgrade.ts
+++ b/packages/react-cli/src/commands/upgrade.ts
@@ -6,9 +6,7 @@ import { appBlueprint } from '../utils/info';
 export class UpgradeCommand extends Command {
   static description = 'Upgrades an existing project';
 
-  static examples = [
-    '$ react upgrade',
-  ];
+  static examples = ['$ react upgrade'];
 
   async run() {
     await ensureDependencies();

--- a/packages/react-cli/src/tasks/download-ts-config.ts
+++ b/packages/react-cli/src/tasks/download-ts-config.ts
@@ -10,19 +10,28 @@ const files = [
   'babelrc.config.js',
 ];
 
-const configPath = 'https://raw.githubusercontent.com/developertown/config-files/master/TypeScript/';
+const configPath =
+  'https://raw.githubusercontent.com/developertown/config-files/master/TypeScript/';
 
-export function downloadTSConfigFiles(path: string) {
-  let taskFns = files.map(file => {
+/**
+ *
+ * @param path relative to the current working directory
+ */
+export function downloadTSConfigFiles(path = './') {
+  let taskFns = files.map((file) => {
     let task = async () => {
       const res = await fetch(`${configPath}${file}`);
+
       await new Promise((resolve, reject) => {
         const fileStream = fs.createWriteStream(`${path}/${file}`);
+
         res.body.pipe(fileStream);
-        res.body.on("error", (err) => {
+
+        res.body.on('error', (err) => {
           reject(err);
         });
-        fileStream.on("finish", function() {
+
+        fileStream.on('finish', function() {
           resolve();
         });
       });
@@ -30,7 +39,7 @@ export function downloadTSConfigFiles(path: string) {
 
     return {
       title: file,
-      task
+      task,
     };
   });
 

--- a/packages/react-cli/src/tasks/ensure-ember-cli-exists.ts
+++ b/packages/react-cli/src/tasks/ensure-ember-cli-exists.ts
@@ -10,13 +10,13 @@ export async function ensureEmberCliExists() {
     let command = 'npm install -g ember-cli';
 
     if (hasNotion()) {
-      command = 'notion install ember-cli'
+      command = 'notion install ember-cli';
     }
 
     let tasks = new Listr([
       {
         title: `Installing ember-cli: '${command}'`,
-        task: () => exec(command)
+        task: () => exec(command),
       },
     ]);
 

--- a/packages/react-cli/src/tasks/ensure-material-exist.ts
+++ b/packages/react-cli/src/tasks/ensure-material-exist.ts
@@ -1,0 +1,23 @@
+import Listr from 'listr';
+import { error, success } from '../utils/print';
+import { exec, doesApplicationHaveModule } from '../utils/shell';
+
+export async function ensureMaterialExists(): Promise<Boolean> {
+    const hasMaterial = await doesApplicationHaveModule('@material');
+    if (!hasMaterial) {
+        error('material is not installed.');
+        
+        let command = 'yarn add @material-ui/core @material-ui/icons';
+
+        let tasks = new Listr([
+            {
+                title: `Installing Material: '${command}'`,
+                task: () => exec(command),
+            },
+        ]);
+
+        await tasks.run();
+        success('Material-UI successfully installed!');
+    }
+    return hasMaterial;
+}

--- a/packages/react-cli/src/tasks/ensure-material-exist.ts
+++ b/packages/react-cli/src/tasks/ensure-material-exist.ts
@@ -2,22 +2,22 @@ import Listr from 'listr';
 import { error, success } from '../utils/print';
 import { exec, doesApplicationHaveModule } from '../utils/shell';
 
-export async function ensureMaterialExists(): Promise<Boolean> {
-    const hasMaterial = await doesApplicationHaveModule('@material');
-    if (!hasMaterial) {
-        error('material is not installed.');
-        
-        let command = 'yarn add @material-ui/core @material-ui/icons';
+export async function ensureMaterialExists(): Promise<boolean> {
+  const hasMaterial = await doesApplicationHaveModule('@material-ui/core');
+  if (!hasMaterial) {
+    error('material is not installed.');
 
-        let tasks = new Listr([
-            {
-                title: `Installing Material: '${command}'`,
-                task: () => exec(command),
-            },
-        ]);
+    let command = 'yarn add @material-ui/core @material-ui/icons';
 
-        await tasks.run();
-        success('Material-UI successfully installed!');
-    }
-    return hasMaterial;
+    let tasks = new Listr([
+      {
+        title: `Installing Material: '${command}'`,
+        task: () => exec(command),
+      },
+    ]);
+
+    await tasks.run();
+    success('Material-UI successfully installed!');
+  }
+  return hasMaterial;
 }

--- a/packages/react-cli/src/tasks/ensure-we-are-in-a-project-directory.ts
+++ b/packages/react-cli/src/tasks/ensure-we-are-in-a-project-directory.ts
@@ -1,0 +1,18 @@
+// https://nodejs.org/api/modules.html#modules_file_modules
+const MODULE_NOT_FOUND = 'MODULE_NOT_FOUND';
+
+export function ensureWeAreInAProjectDirectory() {
+  let packageJson;
+
+  const packagePath = `${process.cwd()}/package.json`;
+
+  try {
+    packageJson = require(packagePath);
+  } catch (e) {
+    if (e.code === MODULE_NOT_FOUND) {
+      throw new Error(`package.json is not in the current working directory: ${packagePath}`);
+    }
+  }
+
+  return; // everything is fine
+}

--- a/packages/react-cli/src/tasks/run-ember.ts
+++ b/packages/react-cli/src/tasks/run-ember.ts
@@ -2,7 +2,6 @@ import { exec } from '../utils/shell';
 import { execSync } from 'child_process';
 
 export async function runEmber(command: string, execOptions = {}) {
-  console.log(command)
   return await exec(`ember ${command}`, execOptions);
 }
 

--- a/packages/react-cli/src/tasks/run-ember.ts
+++ b/packages/react-cli/src/tasks/run-ember.ts
@@ -2,6 +2,7 @@ import { exec } from '../utils/shell';
 import { execSync } from 'child_process';
 
 export async function runEmber(command: string, execOptions = {}) {
+  console.log(command)
   return await exec(`ember ${command}`, execOptions);
 }
 

--- a/packages/react-cli/src/utils/shell.ts
+++ b/packages/react-cli/src/utils/shell.ts
@@ -1,7 +1,7 @@
 import shell from 'shelljs';
 import fs from 'fs';
 
-export function exec(command: string, options = {}) {
+export function exec(command: string, options = {}):Promise<String> {
   return new Promise((resolve, reject) => {
     let bashPath = shell.which('bash').stdout;
 
@@ -14,7 +14,6 @@ export function exec(command: string, options = {}) {
     if (hasNvm()) {
       command = applyNvm(command);
     }
-
     // console.log('hasNotion', hasNotion(), 'full command: ', command);
     shell.exec(
       command,
@@ -57,6 +56,17 @@ export async function doesProgramExist(name: string) {
 
     return path;
   } catch (e) {
+    return false;
+  }
+}
+
+export async function doesApplicationHaveModule(name: string): Promise<Boolean>{
+  try {
+    const moduleList = await exec(`npm ls --parseable --prod`);
+    const hasModule = moduleList.includes(`${name}`)
+
+    return hasModule;
+  } catch(e){
     return false;
   }
 }

--- a/packages/react-cli/src/utils/shell.ts
+++ b/packages/react-cli/src/utils/shell.ts
@@ -1,7 +1,8 @@
 import shell from 'shelljs';
 import fs from 'fs';
+import util from 'util';
 
-export function exec(command: string, options = {}):Promise<String> {
+export function exec(command: string, options = {}): Promise<string> {
   return new Promise((resolve, reject) => {
     let bashPath = shell.which('bash').stdout;
 
@@ -60,15 +61,12 @@ export async function doesProgramExist(name: string) {
   }
 }
 
-export async function doesApplicationHaveModule(name: string): Promise<Boolean>{
-  try {
-    const moduleList = await exec(`npm ls --parseable --prod`);
-    const hasModule = moduleList.includes(`${name}`)
+export async function doesApplicationHaveModule(name: string): Promise<boolean> {
+  const readFile = util.promisify(fs.readFile);
+  const contents = await readFile('./package.json', 'utf8');
+  const contentsToJSON = JSON.parse(contents.toString());
 
-    return hasModule;
-  } catch(e){
-    return false;
-  }
+  return Object.keys(contentsToJSON.dependencies).indexOf(name) != -1;
 }
 
 export function hasNvm() {

--- a/packages/react-generators/.eslintignore
+++ b/packages/react-generators/.eslintignore
@@ -18,3 +18,7 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+
+
+blueprints/component
+blueprints/route

--- a/packages/react-generators/.gitignore
+++ b/packages/react-generators/.gitignore
@@ -22,3 +22,5 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+
+.DS_Store

--- a/packages/react-generators/blueprints/component/files/__root__/__path__/index.tsx
+++ b/packages/react-generators/blueprints/component/files/__root__/__path__/index.tsx
@@ -1,12 +1,59 @@
 import React from 'react';
-
 import './styles';
+<% if (button || card){%>import Button from '@material-ui/core/Button';<%}%>
+<% if (textField){%>import TextField from '@material-ui/core/TextField';<%}%>
+<% if (card){%>import Card from '@material-ui/core/Card';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import Typography from '@material-ui/core/Typography';<%}%>
+<% if (table){%>import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';<%}%>
 
 export default function <%= classifiedModuleName %>() {
-  <%= contents %>
+  <% if (table){%>let rows = [];<%}%>
   return (
-    <>
+    <div>
       A new component named: <%= classifiedModuleName %>
-    </>
+      <% if (button) {%>
+      <Button color="primary"> Button </Button>
+      <%}%>
+      <% if (textField) {%>
+      <TextField
+        label="Name"
+        required
+        value={'Created Text Field'}
+        onChange={}
+      />
+      <%}%>
+      <% if (card) {%><Card >
+        <CardContent>
+          <Typography component="p">
+            Sample Text in the Card
+          </Typography>
+        </CardContent>
+        <CardActions>
+          <Button size="small">Learn More</Button>
+        </CardActions>
+      </Card><%}%>
+      <% if (table) {%><Table >
+        <TableHead>
+          <TableRow>
+            <TableCell>ID</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row, id) => (
+            <TableRow key={id}>
+              <TableCell component="th" scope="row">
+                {row}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table><%}%>
+    </div> 
   );
 };

--- a/packages/react-generators/blueprints/component/files/__root__/__path__/index.tsx
+++ b/packages/react-generators/blueprints/component/files/__root__/__path__/index.tsx
@@ -5,8 +5,6 @@ import './styles';
 export default function <%= classifiedModuleName %>() {
   <%= contents %>
   return (
-    <div>
-      A new component named: <%= classifiedModuleName %>
-    </div>
+    <p>A new component named: <%= classifiedModuleName %></p>
   );
 };

--- a/packages/react-generators/blueprints/component/files/__root__/__path__/index.tsx
+++ b/packages/react-generators/blueprints/component/files/__root__/__path__/index.tsx
@@ -1,59 +1,12 @@
 import React from 'react';
+
 import './styles';
-<% if (button || card){%>import Button from '@material-ui/core/Button';<%}%>
-<% if (textField){%>import TextField from '@material-ui/core/TextField';<%}%>
-<% if (card){%>import Card from '@material-ui/core/Card';
-import CardActions from '@material-ui/core/CardActions';
-import CardContent from '@material-ui/core/CardContent';
-import Typography from '@material-ui/core/Typography';<%}%>
-<% if (table){%>import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';<%}%>
 
 export default function <%= classifiedModuleName %>() {
-  <% if (table){%>let rows = [];<%}%>
+  <%= contents %>
   return (
     <div>
       A new component named: <%= classifiedModuleName %>
-      <% if (button) {%>
-      <Button color="primary"> Button </Button>
-      <%}%>
-      <% if (textField) {%>
-      <TextField
-        label="Name"
-        required
-        value={'Created Text Field'}
-        onChange={}
-      />
-      <%}%>
-      <% if (card) {%><Card >
-        <CardContent>
-          <Typography component="p">
-            Sample Text in the Card
-          </Typography>
-        </CardContent>
-        <CardActions>
-          <Button size="small">Learn More</Button>
-        </CardActions>
-      </Card><%}%>
-      <% if (table) {%><Table >
-        <TableHead>
-          <TableRow>
-            <TableCell>ID</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {rows.map((row, id) => (
-            <TableRow key={id}>
-              <TableCell component="th" scope="row">
-                {row}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table><%}%>
-    </div> 
+    </div>
   );
 };

--- a/packages/react-generators/blueprints/component/index.js
+++ b/packages/react-generators/blueprints/component/index.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const path = require('path');
-const stringUtil = require('ember-cli-string-utils');
-const pathUtil = require('ember-cli-path-utils');
 const normalizeEntityName = require('ember-cli-normalize-entity-name');
 const EOL = require('os').EOL;
 
@@ -40,6 +38,10 @@ module.exports = {
     return {
       contents: contents,
       path: options.path,
+      button: options.button,
+      textField: options.textField,
+      table: options.table,
+      card: options.card
     };
   },
 };

--- a/packages/react-generators/blueprints/material/files/__root__/__path__/__test__/page.ts
+++ b/packages/react-generators/blueprints/material/files/__root__/__path__/__test__/page.ts
@@ -1,0 +1,22 @@
+import {
+    interactor,
+    clickable,
+    text,
+    selectable,
+    scoped,
+    hasClass,
+    isPresent,
+    collection,
+    Interactor,
+  } from '@bigtest/interactor';
+  
+  class Page {
+    // custom interactors here
+  }
+  
+  export const PageInteractor = interactor(Page);
+  
+  export type TInteractor = Page & Interactor;
+  
+  export default new (PageInteractor as any)('#testing-root') as TInteractor;
+  

--- a/packages/react-generators/blueprints/material/files/__root__/__path__/__test__/rendering-test.ts
+++ b/packages/react-generators/blueprints/material/files/__root__/__path__/__test__/rendering-test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { expect, assert } from 'chai';
+
+import { mountWithContext } from 'tests/helpers/mounting';
+
+import <%= classifiedModuleName %> from '..';
+
+import page from './page';
+
+describe('Rendering | <%= classifiedModuleName %>', () => {
+  beforeEach(async function() {
+    await mountWithContext(
+      <%= classifiedModuleName %>
+    );
+  });
+
+  it('renders', () => {
+    expect(page.text).to.contain('A new component named: <%= classifiedModuleName %>');
+  });
+
+  it('does something else', () => {
+    assert(false, 'replace this with a real test');
+  });
+});

--- a/packages/react-generators/blueprints/material/files/__root__/__path__/index.tsx
+++ b/packages/react-generators/blueprints/material/files/__root__/__path__/index.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import './styles';
+<% if (button || card){%>import Button from '@material-ui/core/Button';<%}%>
+<% if (textField){%>import TextField from '@material-ui/core/TextField';<%}%>
+<% if (card){%>import Card from '@material-ui/core/Card';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import Typography from '@material-ui/core/Typography';<%}%>
+<% if (table){%>import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';<%}%>
+
+export default function <%= classifiedModuleName %>() {
+  <% if (table){%>let rows = [];<%}%>
+  return (
+    <div>
+      A new component named: <%= classifiedModuleName %>
+      <% if (button) {%>
+      <Button color="primary"> Button </Button>
+      <%}%>
+      <% if (textField) {%>
+      <TextField
+        label="Name"
+        required
+        value={'Created Text Field'}
+        onChange={}
+      />
+      <%}%>
+      <% if (card) {%><Card >
+        <CardContent>
+          <Typography component="p">
+            Sample Text in the Card
+          </Typography>
+        </CardContent>
+        <CardActions>
+          <Button size="small">Learn More</Button>
+        </CardActions>
+      </Card><%}%>
+      <% if (table) {%>
+      <Table >
+        <TableHead>
+          <TableRow>
+            <TableCell>ID</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row, id) => (
+            <TableRow key={id}>
+              <TableCell component="th" scope="row">
+                {row}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <%} %>
+    </div> 
+  );
+};

--- a/packages/react-generators/blueprints/material/files/__root__/__path__/styles.scss
+++ b/packages/react-generators/blueprints/material/files/__root__/__path__/styles.scss
@@ -1,0 +1,1 @@
+@import '~styles/colors';

--- a/packages/react-generators/blueprints/material/index.js
+++ b/packages/react-generators/blueprints/material/index.js
@@ -1,13 +1,11 @@
 'use strict';
 
 const path = require('path');
-const stringUtil = require('ember-cli-string-utils');
-const pathUtil = require('ember-cli-path-utils');
 const normalizeEntityName = require('ember-cli-normalize-entity-name');
 const EOL = require('os').EOL;
 
 module.exports = {
-  description: 'Generates a component.',
+  description: 'Generates a component with material components.',
 
   availableOptions: [
     { name: 'path', type: String, default: path.join('components') },
@@ -21,7 +19,7 @@ module.exports = {
 
   fileMapTokens: function() {
     return {
-      __root__: function(options) {
+      __root__: function() {
         return path.join('src', 'ui');
       },
       __path__: function(options) {
@@ -40,6 +38,11 @@ module.exports = {
     return {
       contents: contents,
       path: options.path,
+      button: options.button,
+      textField: options.textField,
+      table: options.table,
+      card: options.card
     };
   },
 };
+

--- a/packages/react-generators/blueprints/material/index.js
+++ b/packages/react-generators/blueprints/material/index.js
@@ -2,7 +2,6 @@
 
 const path = require('path');
 const normalizeEntityName = require('ember-cli-normalize-entity-name');
-const EOL = require('os').EOL;
 
 module.exports = {
   description: 'Generates a component with material components.',
@@ -33,10 +32,7 @@ module.exports = {
   },
 
   locals: function(options) {
-    let contents = EOL;
-
     return {
-      contents: contents,
       path: options.path,
       button: options.button,
       textField: options.textField,

--- a/packages/react-generators/index.js
+++ b/packages/react-generators/index.js
@@ -1,10 +1,5 @@
 'use strict';
 
-const path = require('path');
-const rimraf = require('rimraf');
-const fs = require('fs');
-const stringUtil = require('ember-cli-string-utils');
-
 module.exports = {
   description: 'Generators for React Applications.',
   name: '@developertown/react-generator-blueprints',

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cd $PROJECT && yarn install

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cd $PROJECT && yarn lint:js


### PR DESCRIPTION
resolves: #8 

This feature allows for users to generate components with pre existing templates for material components. It would allow for devs to expedite inclusion of specific Material components. Currently there are only included 4 Material Component options **button**, **textField**, **table**, and **card**. 

I can see having only the most used Material Components in the generator. 