### PR TITLE
Upgrades and bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 yarn-error.log
 yarn.lock
 /tmp
+
+# incremental typescript cache
+*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 ## Installation
 
-### [**_notion_**](https://www.notionjs.com/)
+### [**_volta_**](https://volta.sh/)
 ```bash
-notion install @developertown/react-cli
+volta install @developertown/react-cli
 ```
+
+NOTE: if you don't have volta, be sure you have at least some other node manager, such as [nvm](https://github.com/nvm-sh/nvm)
 
 ### **_npm_**
 
@@ -72,10 +74,10 @@ yarn link "@developertown/react-generators-blueprint"
 ### Testing installation
 
 ```bash
-rm -rf ~/.notion
-# install notion
+rm -rf ~/.volta
+# install volta
 # new shell
-notion install node 8
+volta install node
 
 # setup refs to local project
 export REACT_APP_BLUEPRINT_PATH=$HOME/Development/Work/DeveloperTown/react-cli/packages/react-app

--- a/packages/react-app/files/.react-cli.js
+++ b/packages/react-app/files/.react-cli.js
@@ -1,0 +1,28 @@
+'use strict';
+
+
+module.exports = {
+  blueprintVersion: '',
+  features: {
+    <% if (testing) { %>
+      testing: true,
+    <% } %>
+    <% if (jsonapi) { %>
+      jsonapi: true,
+    <% } %>
+    <% if (auth0) { %>
+      auth0: true,
+    <% } %>
+    <% if (i18n) { %>
+      i18n: true,
+    <% } %>
+    <% if (redux) { %>
+      redux: true,
+    <% } %>
+  },
+  styles: {
+    <% if (materialUi) { %>
+      materialUi: true,
+    <% } %>
+  },
+}

--- a/packages/react-app/files/.react-cli.js
+++ b/packages/react-app/files/.react-cli.js
@@ -2,27 +2,16 @@
 
 
 module.exports = {
-  blueprintVersion: '',
+  blueprintVersion: '<%= blueprintVersion %>',
   features: {
-    <% if (testing) { %>
-      testing: true,
-    <% } %>
-    <% if (jsonapi) { %>
-      jsonapi: true,
-    <% } %>
-    <% if (auth0) { %>
-      auth0: true,
-    <% } %>
-    <% if (i18n) { %>
-      i18n: true,
-    <% } %>
-    <% if (redux) { %>
-      redux: true,
-    <% } %>
+    <% if (testing) { %>testing: true,<% } %>
+    <% if (jsonapi) { %>jsonapi: true,<% } %>
+    <% if (auth0) { %>auth0: true,<% } %>
+    <% if (i18n) { %>i18n: true,<% } %>
+    <% if (redux) { %>redux: true,<% } %>
   },
   styles: {
-    <% if (materialUi) { %>
-      materialUi: true,
-    <% } %>
+    <% if (materialUi) { %>materialUi: true,<% } %>
+    <% if (sass) { %>sass: true,<% } %>
   },
 }

--- a/packages/react-app/index.js
+++ b/packages/react-app/index.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const stringUtil = require('ember-cli-string-utils');
+const fsPath = require('path');
+
+const version = require(fsPath.join(__dirname, 'package.json')).version;
 
 module.exports = {
   description: 'Generates a React application.',
@@ -48,8 +51,10 @@ module.exports = {
       jsonapi: options.jsonapi,
       dotnetBackend: options.dotnetBackend,
       materialUi: options.materialUi,
+      sass: options.sass,
       redux: options.redux,
       testing: true,
+      blueprintVersion: version,
     };
   },
 };

--- a/packages/react-cli/src/commands/generate.ts
+++ b/packages/react-cli/src/commands/generate.ts
@@ -1,6 +1,6 @@
 import { Command, flags } from '@oclif/command';
 import { ensureDependencies } from '../tasks/ensure-dependiencies';
-import { runEmber, runEmberInteractively } from '../tasks/run-ember';
+import { runEmberInteractively } from '../tasks/run-ember';
 import { exec } from '../utils/shell';
 
 export class GenerateCommand extends Command {

--- a/packages/react-cli/src/commands/new.ts
+++ b/packages/react-cli/src/commands/new.ts
@@ -1,6 +1,6 @@
 import { Command } from '@oclif/command';
 import { ensureDependencies } from '../tasks/ensure-dependiencies';
-import { runEmber } from '../tasks/run-ember';
+import { runEmberInteractively } from '../tasks/run-ember';
 import inquirer = require('inquirer');
 import Listr from 'listr';
 import { downloadTSConfigFiles } from '../tasks/download-ts-config';
@@ -76,7 +76,7 @@ export class NewCommand extends Command {
     let tasks = new Listr([
       {
         title: 'Creating react project',
-        task: () => runEmber(argsForEmber),
+        task: async () => await runEmberInteractively(argsForEmber),
       },
       {
         title: 'Downloading shared config for DeveloperTown',

--- a/packages/react-cli/src/commands/new.ts
+++ b/packages/react-cli/src/commands/new.ts
@@ -55,12 +55,7 @@ export class NewCommand extends Command {
         name: 'style',
         choices: [
           { name: 'Material UI', value: 'materialUi' },
-          // TODO:
-          // - just sass?
-          //   - sass is default right now, do we want sass to be an option instead?
-          // - bootstrap?
-          // - bulma?
-          // - shoelace?
+          { name: 'SASS', value: 'sass' },
         ],
       },
     ]);

--- a/packages/react-cli/src/commands/new.ts
+++ b/packages/react-cli/src/commands/new.ts
@@ -53,10 +53,7 @@ export class NewCommand extends Command {
         type: 'checkbox',
         message: 'Select UI Framework',
         name: 'style',
-        choices: [
-          { name: 'Material UI', value: 'materialUi' },
-          { name: 'SASS', value: 'sass' },
-        ],
+        choices: [{ name: 'Material UI', value: 'materialUi' }, { name: 'SASS', value: 'sass' }],
       },
     ]);
 

--- a/packages/react-cli/src/commands/upgrade.ts
+++ b/packages/react-cli/src/commands/upgrade.ts
@@ -1,6 +1,6 @@
 import { Command } from '@oclif/command';
 import { ensureDependencies } from '../tasks/ensure-dependiencies';
-import { runEmber, runEmberInteractively } from '../tasks/run-ember';
+import { runEmberInteractively } from '../tasks/run-ember';
 import { appBlueprint } from '../utils/info';
 
 export class UpgradeCommand extends Command {

--- a/packages/react-cli/src/tasks/ensure-ember-cli-exists.ts
+++ b/packages/react-cli/src/tasks/ensure-ember-cli-exists.ts
@@ -1,6 +1,6 @@
 import Listr from 'listr';
 import { error, success } from '../utils/print';
-import { exec, doesProgramExist, hasNotion } from '../utils/shell';
+import { exec, doesProgramExist, hasVolta } from '../utils/shell';
 
 export async function ensureEmberCliExists() {
   const hasEmber = await doesProgramExist('ember');
@@ -9,8 +9,8 @@ export async function ensureEmberCliExists() {
     error('ember-cli is not installed.');
     let command = 'npm install -g ember-cli';
 
-    if (hasNotion()) {
-      command = 'notion install ember-cli';
+    if (hasVolta()) {
+      command = 'volta install ember-cli';
     }
 
     let tasks = new Listr([

--- a/packages/react-cli/src/tasks/ensure-yarn-exists.ts
+++ b/packages/react-cli/src/tasks/ensure-yarn-exists.ts
@@ -1,6 +1,6 @@
 import Listr from 'listr';
 import { error, success } from '../utils/print';
-import { exec, hasNotion, doesProgramExist } from '../utils/shell';
+import { exec, hasVolta, doesProgramExist } from '../utils/shell';
 
 export async function ensureYarnExists() {
   const hasYarn = await doesProgramExist('yarn');
@@ -9,8 +9,8 @@ export async function ensureYarnExists() {
     error('yarn is not installed.');
     let command = 'npm install -g yarn';
 
-    if (hasNotion()) {
-      command = 'notion install yarn';
+    if (hasVolta()) {
+      command = 'volta install yarn';
     }
 
     let tasks = new Listr([

--- a/packages/react-cli/src/tasks/run-ember.ts
+++ b/packages/react-cli/src/tasks/run-ember.ts
@@ -1,9 +1,4 @@
-import { exec } from '../utils/shell';
 import { execSync } from 'child_process';
-
-export async function runEmber(command: string, execOptions = {}) {
-  return await exec(`ember ${command}`, execOptions);
-}
 
 export function runEmberInteractively(command: string) {
   return execSync(`ember ${command}`, { stdio: 'inherit' });

--- a/packages/react-cli/src/utils/shell.ts
+++ b/packages/react-cli/src/utils/shell.ts
@@ -7,15 +7,15 @@ export function exec(command: string, options = {}): Promise<string> {
     let bashPath = shell.which('bash').stdout;
 
     // because this is loaded in login shells,
-    // we need to set up notion manually. :(
-    if (hasNotion()) {
-      command = applyNotion(command);
+    // we need to set up volta manually. :(
+    if (hasVolta()) {
+      command = applyVolta(command);
     }
 
     if (hasNvm()) {
       command = applyNvm(command);
     }
-    // console.log('hasNotion', hasNotion(), 'full command: ', command);
+    // console.log('hasVolta', hasVolta(), 'full command: ', command);
     shell.exec(
       command,
       { silent: true, shell: bashPath, env: { FORCE_COLOR: 'true' }, ...options },
@@ -39,7 +39,7 @@ function applyNvm(command: string) {
   ].join(' && ');
 }
 
-function applyNotion(command: string) {
+function applyVolta(command: string) {
   let path = shell.env['NOTION_HOME'];
   let home = shell.env['HOME'];
 
@@ -77,8 +77,8 @@ export function hasNvm() {
   return fs.existsSync(path);
 }
 
-export function hasNotion() {
-  // return false; // notion has some bugs atm
+export function hasVolta() {
+  // return false; // volta has some bugs atm
   let path = shell.env['NOTION_HOME'];
 
   if (!path) return false;


### PR DESCRIPTION
 - changes notion to volta (they had to rename due to another software called notion (project management tool).
 - add .react-cli.js for knowing what install options were so blueprints can alter what they generate.
  (styles.scss for sass, or styles.ts for jss/css-in-js/whatever)

the file looks like this:
```js
'use strict';

module.exports = {
  blueprintVersion: '0.6.0',
  features: {
      testing: true,
      jsonapi: true,
  },
  styles: {
      materialUi: true,
  },
}
```

what this PR does not do is:
 - implement logic based on the settings in .react-cli.js. separate PRs will be needed for those

Mostly resolves: https://github.com/developertown/react-cli/issues/17